### PR TITLE
Add PyPI search functionality

### DIFF
--- a/burrito/plugins/__init__.py
+++ b/burrito/plugins/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['ircbot', 'greetings', 'dates', 'listcommands', 'locator',
-           'dictionary']
+           'dictionary', "pip"]

--- a/burrito/plugins/pip.py
+++ b/burrito/plugins/pip.py
@@ -7,19 +7,18 @@ import xmlrpc.client
 class Pip(CmdsProvider):
 
     def __init__(self):
-        self.cmds = {
-              'pip': {
-                  'function': self.get_package,
-                  'description': "Get pip package",
-                  'aliases': ['pypi', ],
-              }
-        }
+        self.cmds = {'pip':
+                         {'function': self.get_package,
+                          'description': "Get pip package",
+                          'aliases': ['pypi', ]
+                         }
+                    }
 
         self.xml_rpc = xmlrpc.client.ServerProxy("http://pypi.python.org/pypi")
 
     def get_package(self, command, data):
         """Return the package version and url, or alternatives if not found"""
-        args = " ".join(command.split(":")[1:])
+        args = " ".join(command.split(":")[1:]).strip()
         response = self.xml_rpc.search({"name": args})
 
         alts = []

--- a/burrito/plugins/pip.py
+++ b/burrito/plugins/pip.py
@@ -1,0 +1,45 @@
+from burrito.cmdsprovider import CmdsProvider
+from burrito.utils import reply_to_user
+
+import xmlrpc.client
+
+
+class Pip(CmdsProvider):
+
+    def __init__(self):
+        self.cmds = {
+              'pip': {
+                  'function': self.get_package,
+                  'description': "Get pip package",
+                  'aliases': ['pypi', ],
+              }
+        }
+
+        self.xml_rpc = xmlrpc.client.ServerProxy("http://pypi.python.org/pypi")
+
+    def get_package(self, command, data):
+        """Return the package version and url, or alternatives if not found"""
+        args = " ".join(command.split(":")[1:])
+        response = self.xml_rpc.search({"name": args})
+
+        alts = []
+        for item in response:
+            if item["name"].lower() == args.lower():
+                wanted_data = item
+                break
+            elif args.lower() in item["name"].lower():
+                alts.append(item["name"])
+        else:
+            if alts:
+                reply = "Package {} not found. Alternatives: {}".format(args, " ".join(alts[:10]))
+                return reply_to_user(data, reply)
+            else:
+                return reply_to_user(data, "Package {} not found".format(args))
+
+        response = self.xml_rpc.release_data(wanted_data["name"], wanted_data["version"])
+
+        reply = "{} {}: {}".format(wanted_data["name"],
+                               wanted_data["version"],
+                               response["home_page"])
+
+        return reply_to_user(data, reply)


### PR DESCRIPTION
Allows you to find the package name and URL. **Note: May be vulnerable to XML attacks. See [this](https://docs.python.org/3.4/library/xmlrpc.client.html)**

```
<dmzda> burritobot: pip: flask
<burritobot> dmzda: Flask 0.10.1: http://github.com/mitsuhiko/flask/
<dmzda> burritobot: pip: flask-
<burritobot> dmzda: Package flask- not found. Alternatives: flask-ab Flask-ACL Flask-Actions Flask-Admin Flask-Administration Flask-AlchemyView flask-alchy Flask-Analytics Flask-And-Redis Flask-API
```
